### PR TITLE
Object references for "disconnected" objects

### DIFF
--- a/dataladmetadatamodel/mapper/gitmapper/__init__.py
+++ b/dataladmetadatamodel/mapper/gitmapper/__init__.py
@@ -1,3 +1,4 @@
+import enum
 
 from .datasettreemapper import DatasetTreeGitMapper
 from .filetreemapper import FileTreeGitMapper
@@ -8,6 +9,14 @@ from .textmapper import TextGitMapper
 from .uuidsetmapper import UUIDSetGitMapper
 from .versionlistmapper import TreeVersionListGitMapper
 from .versionlistmapper import VersionListGitMapper
+
+
+class GitReference(enum.Enum):
+    TREE_VERSION_LIST = "refs/datalad/dataset-tree"
+    UUID_SET = "refs/datalad/dataset-set"
+    DATASET_TREE = "refs/datalad/object-references/dataset-tree"
+    METADATA = "refs/datalad/object-references/metadata"
+    FILE_TREE = "refs/datalad/object-references/file-tree"
 
 
 GIT_MAPPER_FAMILY_MEMBERS = {

--- a/dataladmetadatamodel/mapper/gitmapper/__init__.py
+++ b/dataladmetadatamodel/mapper/gitmapper/__init__.py
@@ -1,22 +1,14 @@
-import enum
 
 from .datasettreemapper import DatasetTreeGitMapper
 from .filetreemapper import FileTreeGitMapper
 from .metadatamapper import MetadataGitMapper
 from .metadatarootrecordmapper import MetadataRootRecordGitMapper
+from .filetreemapper import GitReference
 from .referencemapper import ReferenceGitMapper
 from .textmapper import TextGitMapper
 from .uuidsetmapper import UUIDSetGitMapper
 from .versionlistmapper import TreeVersionListGitMapper
 from .versionlistmapper import VersionListGitMapper
-
-
-class GitReference(enum.Enum):
-    TREE_VERSION_LIST = "refs/datalad/dataset-tree"
-    UUID_SET = "refs/datalad/dataset-set"
-    DATASET_TREE = "refs/datalad/object-references/dataset-tree"
-    METADATA = "refs/datalad/object-references/metadata"
-    FILE_TREE = "refs/datalad/object-references/file-tree"
 
 
 GIT_MAPPER_FAMILY_MEMBERS = {
@@ -32,8 +24,7 @@ GIT_MAPPER_FAMILY_MEMBERS = {
 }
 
 
-TREE_VERSION_LIST_REFERENCE = "refs/datalad/dataset-tree"
-UUID_SET_REFERENCE = "refs/datalad/dataset-set"
-
-
-GIT_MAPPER_LOCATIONS = (TREE_VERSION_LIST_REFERENCE, UUID_SET_REFERENCE)
+GIT_MAPPER_LOCATIONS = (
+    GitReference.TREE_VERSION_LIST.value,
+    GitReference.UUID_SET.value
+)

--- a/dataladmetadatamodel/mapper/gitmapper/datasettreemapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/datasettreemapper.py
@@ -1,4 +1,6 @@
 
+from . import GitReference
+from .objectreference import add_tree_reference
 from .gitbackend.subprocess import git_ls_tree_recursive, git_save_tree
 from .metadatarootrecordmapper import MetadataRootRecordGitMapper
 from ..basemapper import BaseMapper
@@ -66,4 +68,6 @@ class DatasetTreeGitMapper(BaseMapper):
         from dataladmetadatamodel.datasettree import DatasetTree
 
         assert isinstance(obj, DatasetTree)
-        return self._save_dataset_tree(obj)
+        dataset_tree_hash = self._save_dataset_tree(obj)
+        add_tree_reference(self.realm, GitReference.DATASET_TREE, dataset_tree_hash)
+        return dataset_tree_hash

--- a/dataladmetadatamodel/mapper/gitmapper/datasettreemapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/datasettreemapper.py
@@ -1,6 +1,5 @@
 
-from . import GitReference
-from .objectreference import add_tree_reference
+from .objectreference import GitReference, add_tree_reference
 from .gitbackend.subprocess import git_ls_tree_recursive, git_save_tree
 from .metadatarootrecordmapper import MetadataRootRecordGitMapper
 from ..basemapper import BaseMapper

--- a/dataladmetadatamodel/mapper/gitmapper/filetreemapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/filetreemapper.py
@@ -1,5 +1,6 @@
 
-
+from . import GitReference
+from .objectreference import add_tree_reference
 from .gitbackend.subprocess import git_load_str, git_ls_tree_recursive, git_save_str, git_save_tree
 from ..basemapper import BaseMapper
 from ..reference import Reference
@@ -53,4 +54,6 @@ class FileTreeGitMapper(BaseMapper):
         from dataladmetadatamodel.filetree import FileTree
 
         assert isinstance(obj, FileTree)
-        return self._save_file_tree(obj)
+        file_tree_hash = self._save_file_tree(obj)
+        add_tree_reference(self.realm, GitReference.FILE_TREE, file_tree_hash)
+        return file_tree_hash

--- a/dataladmetadatamodel/mapper/gitmapper/filetreemapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/filetreemapper.py
@@ -1,6 +1,5 @@
 
-from . import GitReference
-from .objectreference import add_tree_reference
+from .objectreference import GitReference, add_tree_reference
 from .gitbackend.subprocess import git_load_str, git_ls_tree_recursive, git_save_str, git_save_tree
 from ..basemapper import BaseMapper
 from ..reference import Reference
@@ -55,5 +54,6 @@ class FileTreeGitMapper(BaseMapper):
 
         assert isinstance(obj, FileTree)
         file_tree_hash = self._save_file_tree(obj)
-        add_tree_reference(self.realm, GitReference.FILE_TREE, file_tree_hash)
+        if file_tree_hash != empty_tree_location:
+            add_tree_reference(self.realm, GitReference.FILE_TREE, file_tree_hash)
         return file_tree_hash

--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -1,6 +1,5 @@
 
-from . import GitReference
-from .objectreference import add_blob_reference
+from .objectreference import GitReference, add_blob_reference
 from .gitbackend.subprocess import git_load_str, git_save_str
 from ..basemapper import BaseMapper
 from ..reference import Reference

--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -1,4 +1,6 @@
 
+from . import GitReference
+from .objectreference import add_blob_reference
 from .gitbackend.subprocess import git_load_str, git_save_str
 from ..basemapper import BaseMapper
 from ..reference import Reference
@@ -15,6 +17,11 @@ class MetadataGitMapper(BaseMapper):
     def unmap(self, obj) -> str:
         from dataladmetadatamodel.metadata import Metadata
         assert isinstance(obj, Metadata)
-        return git_save_str(self.realm, obj.to_json())
 
-
+        metadata_object_hash = git_save_str(self.realm, obj.to_json())
+        add_blob_reference(
+            self.realm,
+            GitReference.METADATA,
+            metadata_object_hash
+        )
+        return metadata_object_hash

--- a/dataladmetadatamodel/mapper/gitmapper/objectreference.py
+++ b/dataladmetadatamodel/mapper/gitmapper/objectreference.py
@@ -1,6 +1,14 @@
+import enum
 
-from . import GitReference
-from .gitbackend.subprocess import git_ls_tree, git_save_tree
+from .gitbackend.subprocess import git_ls_tree, git_update_ref, git_save_tree
+
+
+class GitReference(enum.Enum):
+    TREE_VERSION_LIST = "refs/datalad/dataset-tree-version-list"
+    UUID_SET = "refs/datalad/dataset-uuid-set"
+    DATASET_TREE = "refs/datalad/object-references/dataset-tree"
+    METADATA = "refs/datalad/object-references/metadata"
+    FILE_TREE = "refs/datalad/object-references/file-tree"
 
 
 def add_object_reference(realm: str,
@@ -22,7 +30,8 @@ def add_object_reference(realm: str,
         object_hash,
         "object_reference:" + object_hash
     ))
-    git_save_tree(realm, existing_tree_entries)
+    tree_hash = git_save_tree(realm, existing_tree_entries)
+    git_update_ref(realm, git_reference.value, tree_hash)
 
 
 def add_tree_reference(realm: str,

--- a/dataladmetadatamodel/mapper/gitmapper/objectreference.py
+++ b/dataladmetadatamodel/mapper/gitmapper/objectreference.py
@@ -1,0 +1,55 @@
+
+from . import GitReference
+from .gitbackend.subprocess import git_ls_tree, git_save_tree
+
+
+def add_object_reference(realm: str,
+                         git_reference: GitReference,
+                         flag: str,
+                         object_type: str,
+                         object_hash: str):
+    try:
+        existing_tree_entries = [
+            tuple(line.split())
+            for line in git_ls_tree(realm, git_reference.value)
+        ]
+    except RuntimeError:
+        existing_tree_entries = []
+
+    existing_tree_entries.append((
+        flag,
+        object_type,
+        object_hash,
+        "object_reference:" + object_hash
+    ))
+    git_save_tree(realm, existing_tree_entries)
+
+
+def add_tree_reference(realm: str,
+                       git_reference: GitReference,
+                       object_hash: str):
+
+    add_object_reference(
+        realm,
+        git_reference,
+        "040000",
+        "tree",
+        object_hash
+    )
+
+
+def add_blob_reference(realm: str,
+                       git_reference: GitReference,
+                       object_hash: str):
+
+    add_object_reference(
+        realm,
+        git_reference,
+        "100644",
+        "blob",
+        object_hash
+    )
+
+
+def remove_object_reference(*args, **kwargs):
+    raise NotImplementedError

--- a/dataladmetadatamodel/mapper/gitmapper/versionlistmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/versionlistmapper.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from .objectreference import GitReference
 from .gitbackend.subprocess import git_load_json, git_save_json, git_update_ref
 from ..basemapper import BaseMapper
 from ..reference import Reference
@@ -71,8 +72,7 @@ class TreeVersionListGitMapper(VersionListGitMapper):
 
     def unmap(self, obj: Any) -> str:
         # Import in method to prevent recursive imports
-        from . import TREE_VERSION_LIST_REFERENCE
 
         location = super().unmap(obj)
-        git_update_ref(self.realm, TREE_VERSION_LIST_REFERENCE, location)
-        return TREE_VERSION_LIST_REFERENCE
+        git_update_ref(self.realm, GitReference.TREE_VERSION_LIST.value, location)
+        return GitReference.TREE_VERSION_LIST.value


### PR DESCRIPTION
Fixes issue #1 

Disconnected objects are referenced by git-tree-objects that are in turn referenced by git refs.
The following model classes are referenced in the gitven git refs:

- TreeVersionList:   refs/datalad/dataset-tree-version-list
- UUIDSet: refs/datalad/dataset-uuid-set
- DatasetTree: refs/datalad/object-references/dataset-tree
- Metadata: refs/datalad/object-references/metadata
- FileTree: refs/datalad/object-references/file-tree

